### PR TITLE
Update to v4.0.0

### DIFF
--- a/org.altaqwaa.Altaqwaa.metainfo.xml
+++ b/org.altaqwaa.Altaqwaa.metainfo.xml
@@ -37,18 +37,26 @@
   <screenshots>
     <screenshot type="default">
       <caption>Main menu</caption>
-      <image>https://raw.githubusercontent.com/rn0x/Altaqwaa-Islamic-Desktop-Application/main/screenshots/dark/1.png</image>
+      <image>https://raw.githubusercontent.com/rn0x/altaqwaa-desktop/v4/screenshots/home-dark.png</image>
     </screenshot>
     <screenshot>
-      <caption>Adhkar menu</caption>
-      <image>https://raw.githubusercontent.com/rn0x/Altaqwaa-Islamic-Desktop-Application/main/screenshots/dark/6.png</image>
-    </screenshot>
-    <screenshot>
-      <caption>Quran menu</caption>
-      <image>https://raw.githubusercontent.com/rn0x/Altaqwaa-Islamic-Desktop-Application/main/screenshots/light/3.png</image>
+      <caption>Main menu (light)</caption>
+      <image>https://raw.githubusercontent.com/rn0x/altaqwaa-desktop/v4/screenshots/home-light.png</image>
     </screenshot>
   </screenshots>
   <releases>
+    <release version="4.0.0" date="2026-08-07">
+      <url>https://github.com/rn0x/altaqwaa-desktop/releases/tag/v4.0.0</url>
+      <description>
+        <ul>
+          <li>إعادة بناء كاملة بواجهة عصرية (Electron + React).</li>
+          <li>مكتبة إسلامية مدمجة تضم أكثر من 35,000 عنصر تعمل دون الحاجة للإنترنت.</li>
+          <li>تخصيص كامل للألوان والوضع الليلي.</li>
+          <li>التزامن بين الأجهزة.</li>
+          <li>تحسينات كبيرة في الأداء والإستقرار.</li>
+        </ul>
+      </description>
+    </release>
     <release version="3.0.1" date="2023-03-16">
       <url>https://github.com/rn0x/altaqwaa-desktop/releases/tag/v3.0.1</url>
       <description>

--- a/org.altaqwaa.Altaqwaa.yml
+++ b/org.altaqwaa.Altaqwaa.yml
@@ -19,17 +19,17 @@ modules:
   - name: altaqwaa
     buildsystem: simple
     build-commands:
-      - mv * /app/bin
+      - mv altaqwaa-4.0.0/* /app/bin
       - mkdir -p /app/share/icons/hicolor/256x256/apps/
       - mkdir -p /app/share/applications
       - mkdir -p /app/share/metainfo
-      - mv /app/bin/${FLATPAK_ID}.png /app/share/icons/hicolor/256x256/apps/
-      - mv /app/bin/${FLATPAK_ID}.desktop /app/share/applications/
-      - mv /app/bin/${FLATPAK_ID}.metainfo.xml /app/share/metainfo
+      - mv ${FLATPAK_ID}.png /app/share/icons/hicolor/256x256/apps/
+      - mv ${FLATPAK_ID}.desktop /app/share/applications/
+      - mv ${FLATPAK_ID}.metainfo.xml /app/share/metainfo
     sources:
       - type: archive
-        url: https://github.com/rn0x/altaqwaa-desktop/releases/download/v3.0.1/altaqwaa-3.0.1.tar.gz
-        sha256: ed7bd6ce3876e95a973f06247b0d1ed41858dbae46958f48df0d8bb2ad00ee7b
+        url: https://github.com/rn0x/altaqwaa-desktop/releases/download/v4.0.0/altaqwaa-4.0.0.tar.gz
+        sha256: 99e2e4dfd066f1ee1f6c4cda9cd9f8378da2d372f6e037f94a69c5d150282b12
       # Wrapper to launch the app
       - type: file
         path: run.sh

--- a/org.altaqwaa.Altaqwaa.yml
+++ b/org.altaqwaa.Altaqwaa.yml
@@ -19,13 +19,13 @@ modules:
   - name: altaqwaa
     buildsystem: simple
     build-commands:
-      - mv altaqwaa-4.0.0/* /app/bin
+      - mv * /app/bin
       - mkdir -p /app/share/icons/hicolor/256x256/apps/
       - mkdir -p /app/share/applications
       - mkdir -p /app/share/metainfo
-      - mv ${FLATPAK_ID}.png /app/share/icons/hicolor/256x256/apps/
-      - mv ${FLATPAK_ID}.desktop /app/share/applications/
-      - mv ${FLATPAK_ID}.metainfo.xml /app/share/metainfo
+      - mv /app/bin/${FLATPAK_ID}.png /app/share/icons/hicolor/256x256/apps/
+      - mv /app/bin/${FLATPAK_ID}.desktop /app/share/applications/
+      - mv /app/bin/${FLATPAK_ID}.metainfo.xml /app/share/metainfo
     sources:
       - type: archive
         url: https://github.com/rn0x/altaqwaa-desktop/releases/download/v4.0.0/altaqwaa-4.0.0.tar.gz


### PR DESCRIPTION
Update to Altaqwaa v4.0.0

- New upstream tarball (altaqwaa-4.0.0.tar.gz, sha256 99e2e4df...)
- Adjust build-commands for the new tarball layout (altaqwaa-4.0.0/ top-level dir)
- Add 4.0.0 release entry to metainfo
- Refresh screenshots from the new repository